### PR TITLE
Further fixes for tests etc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,7 @@ jobs:
 
       - name: Run tests
         run: |
-          devtools::test("lostruct")
+          res=devtools::test("lostruct")
+          df=as.data.frame(res)
+          if(sum(df$failed) > 0 || any(df$error)) {q(status=1)}
         shell: Rscript {0}

--- a/lostruct/tests/testthat/test_vcf_windower.R
+++ b/lostruct/tests/testthat/test_vcf_windower.R
@@ -123,7 +123,7 @@ context("with a pipe in the contig name")
 # copy of test.bcf but with contig named "2|false"
 bcf.file <- "test_with_pipes.bcf"
 
-vcf.text <- read.table("test_with_pipes.vcf", sep="\t", skip=30, header=TRUE, comment.char="" )
+vcf.text <- read.table("test_with_pipes.vcf", sep="\t", skip=30, header=TRUE, comment.char="", check.names=F)
 vcf.mat <- vcf.text[,10:16]
 
 # read in data


### PR DESCRIPTION
Hi Peter,
I realised after you merged that PR overnight that the tests were failing, but `devtools::test()` didn't exit non-zero. This means that github actions didn't recognise the failure. This pr both fixes the GH actions script, and the failing test (hopefully, dont merge it ill does).

Cheers,
Kevin